### PR TITLE
Leaderboard Display Improvements

### DIFF
--- a/web/src/table/Table.vue
+++ b/web/src/table/Table.vue
@@ -13,6 +13,7 @@ import {
   findSplit,
   type Submission
 } from './data'
+import TableCell from '@/table/TableCell.vue'
 
 // setup
 const props = defineProps<{
@@ -34,7 +35,6 @@ const selectedDecoding = ref('all')
 const selectedRepetition = ref('all')
 const selectedAttack = ref('none')
 
-
 // computed
 const filteredSortedData = computed(() => {
   // RAID specific: select the right score from the settings
@@ -50,13 +50,43 @@ const filteredSortedData = computed(() => {
     for (const [sorterKey, direction] of sortOrders) {
       let val = 0
       if (direction === SortOrder.ASC) {
-        val = numeric((datum) => findSplit(datum, sorterKey, selectedDomain.value, selectedDecoding.value, selectedRepetition.value, selectedAttack.value)?.accuracy ?? -999)(a, b)
+        val = numeric(
+          (datum) =>
+            findSplit(
+              datum,
+              sorterKey,
+              selectedDomain.value,
+              selectedDecoding.value,
+              selectedRepetition.value,
+              selectedAttack.value
+            )?.accuracy ?? -999
+        )(a, b)
       } else if (direction === SortOrder.DESC) {
-        val = numericDesc((datum) => findSplit(datum, sorterKey, selectedDomain.value, selectedDecoding.value, selectedRepetition.value, selectedAttack.value)?.accuracy ?? -999)(a, b)
+        val = numericDesc(
+          (datum) =>
+            findSplit(
+              datum,
+              sorterKey,
+              selectedDomain.value,
+              selectedDecoding.value,
+              selectedRepetition.value,
+              selectedAttack.value
+            )?.accuracy ?? -999
+        )(a, b)
       }
       if (val) return val
     }
-    return numericDesc((datum) => findSplit(datum, 'all', selectedDomain.value, selectedDecoding.value, selectedRepetition.value, selectedAttack.value)?.accuracy ?? -999)(a, b)
+    return numericDesc(
+      (datum) =>
+        findSplit(
+          datum,
+          'all',
+          selectedDomain.value,
+          selectedDecoding.value,
+          selectedRepetition.value,
+          selectedAttack.value
+        )?.accuracy ?? -999
+    )(a, b)
   })
 })
 
@@ -307,19 +337,19 @@ function isMaximum(
   <div class="table-container mt-4">
     <table class="table is-striped is-fullwidth is-hoverable">
       <thead>
-      <tr>
-        <th colspan="2" class="superheader"></th>
-        <th :colspan="ALL_GENERATOR_MODELS.length" class="superheader has-text-centered">
-          Generator Model
-        </th>
-      </tr>
-      <tr>
-        <th>
+        <tr>
+          <th colspan="2" class="superheader"></th>
+          <th :colspan="ALL_GENERATOR_MODELS.length" class="superheader has-text-centered">
+            Generator Model
+          </th>
+        </tr>
+        <tr>
+          <th>
             <span class="icon-text">
               <span>Detector</span>
             </span>
-        </th>
-        <th>
+          </th>
+          <th>
             <span class="icon-text">
               <span>Aggregate</span>
               <SortIcon
@@ -330,9 +360,9 @@ function isMaximum(
                 @directionChanged="onSortDirectionChange('all', $event)"
               />
             </span>
-        </th>
-        <th v-for="gen in ALL_GENERATOR_MODELS">
-          <span class="icon-text">
+          </th>
+          <th v-for="gen in ALL_GENERATOR_MODELS">
+            <span class="icon-text">
               <span>{{ gen }}</span>
               <SortIcon
                 class="ml-1"
@@ -342,8 +372,8 @@ function isMaximum(
                 @directionChanged="onSortDirectionChange(gen, $event)"
               />
             </span>
-        </th>
-      </tr>
+          </th>
+        </tr>
       </thead>
 
       <TransitionGroup tag="tbody" name="lb-rows">
@@ -356,38 +386,41 @@ function isMaximum(
             <div class="icon-text">
               <a :href="datum.website" v-if="datum.website" target="_blank">🌐 </a>
               <a :href="datum.paper_link" v-if="datum.paper_link" target="_blank">📄 </a>
-              <a :href="datum.huggingface_link" v-if="datum.huggingface_link" target="_blank">🤗 </a>
-              <a :href="datum.github_link" v-if="datum.github_link" target="_blank" style="padding-top: 1px">
+              <a :href="datum.huggingface_link" v-if="datum.huggingface_link" target="_blank"
+                >🤗
+              </a>
+              <a
+                :href="datum.github_link"
+                v-if="datum.github_link"
+                target="_blank"
+                style="padding-top: 1px"
+              >
                 <!-- dirty css hack but it works -->
                 <span class="icon is-small">
-                  <img src="@/assets/github-mark.svg">
+                  <img src="@/assets/github-mark.svg" />
                 </span>
               </a>
             </div>
           </td>
-          <td
-            :class="{
-              'has-text-weight-bold': isMaximum(
-                findSplit(datum, 'all', selectedDomain, selectedDecoding, selectedRepetition, selectedAttack)?.accuracy ?? 0,
-                (d) => findSplit(d, 'all', selectedDomain, selectedDecoding, selectedRepetition, selectedAttack)?.accuracy ?? 0
-              )
-            }"
-          >
-            {{ findSplit(datum, 'all', selectedDomain, selectedDecoding, selectedRepetition, selectedAttack)?.accuracy?.toFixed(3) ?? '--'
-            }}
-          </td>
-          <td
+          <TableCell
+            :datum="datum"
+            model="all"
+            :selected-domain="selectedDomain"
+            :selected-decoding="selectedDecoding"
+            :selected-repetition="selectedRepetition"
+            :selected-attack="selectedAttack"
+            :is-maximum="isMaximum"
+          />
+          <TableCell
             v-for="gen in ALL_GENERATOR_MODELS"
-            :class="{
-              'has-text-weight-bold': isMaximum(
-                findSplit(datum, gen, selectedDomain, selectedDecoding, selectedRepetition, selectedAttack)?.accuracy ?? 0,
-                (d) => findSplit(d, gen, selectedDomain, selectedDecoding, selectedRepetition, selectedAttack)?.accuracy ?? 0
-              )
-            }"
-          >
-            {{ findSplit(datum, gen, selectedDomain, selectedDecoding, selectedRepetition, selectedAttack)?.accuracy?.toFixed(3) ?? '--'
-            }}
-          </td>
+            :datum="datum"
+            :model="gen"
+            :selected-domain="selectedDomain"
+            :selected-decoding="selectedDecoding"
+            :selected-repetition="selectedRepetition"
+            :selected-attack="selectedAttack"
+            :is-maximum="isMaximum"
+          />
         </tr>
       </TransitionGroup>
     </table>
@@ -431,11 +464,11 @@ function isMaximum(
   width: 100%;
 }
 
-.lb-rows-move {
-  transition: all 0.5s ease;
-}
-
 .superheader {
   border-bottom: none;
+}
+
+.lb-rows-move {
+  transition: all 0.5s ease;
 }
 </style>

--- a/web/src/table/Table.vue
+++ b/web/src/table/Table.vue
@@ -234,11 +234,11 @@ function isMaximum(
       <!--      </div>-->
       <!-- domain -->
       <div class="level-item">
-        <div class="field">
+        <div class="field filter-control">
           <label class="label">Domain</label>
-          <div class="control">
-            <div class="select">
-              <select v-model="selectedDomain" @change="updateQueryParams()">
+          <div class="control w-100">
+            <div class="select w-100">
+              <select class="w-100" v-model="selectedDomain" @change="updateQueryParams()">
                 <option>all</option>
                 <option v-for="domain in ALL_DOMAINS">{{ domain }}</option>
               </select>
@@ -248,11 +248,11 @@ function isMaximum(
       </div>
       <!-- decoding -->
       <div class="level-item">
-        <div class="field">
+        <div class="field filter-control">
           <label class="label">Decoding Strategy</label>
-          <div class="control">
-            <div class="select">
-              <select v-model="selectedDecoding" @change="updateQueryParams()">
+          <div class="control w-100">
+            <div class="select w-100">
+              <select class="w-100" v-model="selectedDecoding" @change="updateQueryParams()">
                 <option>all</option>
                 <option v-for="decoding in ALL_DECODINGS">{{ decoding }}</option>
               </select>
@@ -262,11 +262,11 @@ function isMaximum(
       </div>
       <!-- rep -->
       <div class="level-item">
-        <div class="field">
+        <div class="field filter-control">
           <label class="label">Repetition Penalty</label>
-          <div class="control">
-            <div class="select">
-              <select v-model="selectedRepetition" @change="updateQueryParams()">
+          <div class="control w-100">
+            <div class="select w-100">
+              <select class="w-100" v-model="selectedRepetition" @change="updateQueryParams()">
                 <option>all</option>
                 <option v-for="rep in ALL_REPETITION_PENALTIES">{{ rep }}</option>
               </select>
@@ -276,11 +276,11 @@ function isMaximum(
       </div>
       <!-- attack -->
       <div class="level-item">
-        <div class="field">
+        <div class="field filter-control">
           <label class="label">Adversarial Attack</label>
-          <div class="control">
-            <div class="select">
-              <select v-model="selectedAttack" @change="updateQueryParams()">
+          <div class="control w-100">
+            <div class="select w-100">
+              <select class="w-100" v-model="selectedAttack" @change="updateQueryParams()">
                 <option>none</option>
                 <option>all</option>
                 <option v-for="atk in ALL_ATTACKS">{{ atk }}</option>
@@ -308,9 +308,15 @@ function isMaximum(
     <table class="table is-striped is-fullwidth is-hoverable">
       <thead>
       <tr>
+        <th colspan="2" class="superheader"></th>
+        <th :colspan="ALL_GENERATOR_MODELS.length" class="superheader has-text-centered">
+          Generator Model
+        </th>
+      </tr>
+      <tr>
         <th>
             <span class="icon-text">
-              <span>Model</span>
+              <span>Detector</span>
             </span>
         </th>
         <th>
@@ -417,7 +423,19 @@ function isMaximum(
   min-height: 350px;
 }
 
+.filter-control {
+  min-width: 12rem;
+}
+
+.w-100 {
+  width: 100%;
+}
+
 .lb-rows-move {
   transition: all 0.5s ease;
+}
+
+.superheader {
+  border-bottom: none;
 }
 </style>

--- a/web/src/table/TableCell.vue
+++ b/web/src/table/TableCell.vue
@@ -23,11 +23,11 @@ const split = computed(() =>
   )
 )
 
-function getCellColor() {
+const cellColor = computed(() => {
   const acc = split.value?.accuracy
-  if (acc === undefined || acc === null) return 'none'
+  if (acc === undefined || acc === null) return 'transparent'
   return `hsla(${120 * acc}, 100%, 60%, 0.5)`
-}
+})
 </script>
 
 <template>
@@ -41,7 +41,7 @@ function getCellColor() {
       )
     }"
     :style="{
-      'background-color': getCellColor()
+      'background-color': cellColor
     }"
     class="lb-cell"
   >

--- a/web/src/table/TableCell.vue
+++ b/web/src/table/TableCell.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { type Datum, findSplit } from '@/table/data'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  datum: Datum
+  model: string
+  selectedDomain: string
+  selectedDecoding: string
+  selectedRepetition: string
+  selectedAttack: string
+  isMaximum: (x: number, attr: (datum: Datum) => number, round?: (x: number) => any) => boolean
+}>()
+
+const split = computed(() =>
+  findSplit(
+    props.datum,
+    props.model,
+    props.selectedDomain,
+    props.selectedDecoding,
+    props.selectedRepetition,
+    props.selectedAttack
+  )
+)
+
+function getCellColor() {
+  const acc = split.value?.accuracy
+  if (acc === undefined || acc === null) return 'none'
+  return `hsla(${120 * acc}, 100%, 60%, 0.5)`
+}
+</script>
+
+<template>
+  <td
+    :class="{
+      'has-text-weight-bold': isMaximum(
+        split?.accuracy ?? 0,
+        (d) =>
+          findSplit(d, model, selectedDomain, selectedDecoding, selectedRepetition, selectedAttack)
+            ?.accuracy ?? 0
+      )
+    }"
+    :style="{
+      'background-color': getCellColor()
+    }"
+    class="lb-cell"
+  >
+    {{ split?.accuracy?.toFixed(3) ?? '--' }}
+  </td>
+</template>
+
+<style scoped></style>

--- a/web/src/table/data.ts
+++ b/web/src/table/data.ts
@@ -40,11 +40,25 @@ export function findSplit(datum: Datum, model: string = 'all', domain: string = 
 // consts
 export const ALL_SCORES: Submission[] = allScores
 // ASSUMPTION: there is at least one submission and all submissions have the same (model, domain, decoding, repetition_penalty) options
-export const ALL_GENERATOR_MODELS = ALL_SCORES.map(sub => sub.scores)
-  .flat()
-  .map((s) => s.model)
-  .filter(unique)
-  .filter(noAll)
+// export const ALL_GENERATOR_MODELS = ALL_SCORES.map(sub => sub.scores)
+//   .flat()
+//   .map((s) => s.model)
+//   .filter(unique)
+//   .filter(noAll)
+// we hardcode this to the set included in RAID for display ordering
+export const ALL_GENERATOR_MODELS = [
+  "chatgpt",
+  "gpt4",
+  "gpt3",
+  "gpt2",
+  "mistral",
+  "mistral-chat",
+  "cohere",
+  "cohere-chat",
+  "llama-chat",
+  "mpt",
+  "mpt-chat",
+];
 export const ALL_DOMAINS = ALL_SCORES.map(sub => sub.scores)
   .flat()
   .map((s) => s.domain)


### PR DESCRIPTION
- Fixed the order of the generator models: left-to-right, it displays:
```
[
  "chatgpt",
  "gpt4",
  "gpt3",
  "gpt2",
  "mistral",
  "mistral-chat",
  "cohere",
  "cohere-chat",
  "llama-chat",
  "mpt",
  "mpt-chat",
]
```
- Added a "Generator Model" superheader
- Made filter dropdowns a fixed width
- Colored table cell backgrounds red->green based on performance