### PR TITLE
Remove unnecessary fields from ADAL metadata

### DIFF
--- a/leaderboard/submissions/ADAL/metadata.json
+++ b/leaderboard/submissions/ADAL/metadata.json
@@ -1,8 +1,6 @@
 {
     "date_released": "2026-04-13",
     "detector_name": "ADAL",
-    "website": "Link to Homepage",
-    "paper_link": "Link to Paper",
     "huggingface_link": "https://huggingface.co/Shushant/ADAL-detector-large",
     "github_link": "https://github.com/ShushantaTUD/ADAL_AI_Detector",
     "contact_info": "D23129142@mytudublin.ie"


### PR DESCRIPTION
Removed website and paper link fields from metadata.