### PR TITLE
Add kp-detect-v16 submission

### DIFF
--- a/leaderboard/submissions/kp-detect-v16/README.md
+++ b/leaderboard/submissions/kp-detect-v16/README.md
@@ -1,0 +1,12 @@
+Text classifier submission. Predictions for the RAID held-out test set.
+
+## predictions.json
+
+JSON array of `{"id": <uuid>, "score": <float in [0,1]>}` objects, one per
+RAID test row. `score` is the probability that the row is machine-generated;
+higher means more likely machine-generated.
+
+## metadata.json
+
+Three fields per the RAID submission spec: `date_released`, `detector_name`,
+`contact_info`.

--- a/leaderboard/submissions/kp-detect-v16/metadata.json
+++ b/leaderboard/submissions/kp-detect-v16/metadata.json
@@ -1,0 +1,5 @@
+{
+  "date_released": "2026-05-23",
+  "detector_name": "Kareem Elsamadicy (Independent Researcher)",
+  "contact_info": "kelsamadicy@gmail.com"
+}


### PR DESCRIPTION
Adds kp-detect-v16: stacked ensemble of two per-row scorers with meta-stacker calibration. predictions.json covers all 672K test ids (id + score only). Author: Kareem Elsamadicy (Independent Researcher) — kelsamadicy@gmail.com.